### PR TITLE
feat: validar existencia de materia prima antes de registrar compra y documentacion

### DIFF
--- a/GeneraterSwagger.json
+++ b/GeneraterSwagger.json
@@ -1,0 +1,304 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "API para el sistema de inventario de AMARA SAS",
+    "description": "Esta API permite gestionar todo el sistema de invitenario de la produccion de quesos de la empresa AMARA SAS",
+    "version": "1.0.0"
+  },
+  "host": "amara-backend-production.up.railway.app",
+  "basePath": "/",
+  "schemes": [
+    "https"
+  ],
+  "paths": {
+    "/api/perfil": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/personas/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/personas/{id}": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/login": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "nombre_usuario": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/verify": {
+      "get": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
+    "/api/cliente/createCltProv": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cedula_nit": {
+                  "example": "any"
+                },
+                "nombre": {
+                  "example": "any"
+                },
+                "apellido": {
+                  "example": "any"
+                },
+                "celular": {
+                  "example": "any"
+                },
+                "tipo_persona": {
+                  "example": "any"
+                },
+                "edad": {
+                  "example": "any"
+                },
+                "direccion": {
+                  "example": "any"
+                },
+                "correo": {
+                  "example": "any"
+                },
+                "tipo_relacion": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/proveedor/createCltProv": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cedula_nit": {
+                  "example": "any"
+                },
+                "nombre": {
+                  "example": "any"
+                },
+                "apellido": {
+                  "example": "any"
+                },
+                "celular": {
+                  "example": "any"
+                },
+                "tipo_persona": {
+                  "example": "any"
+                },
+                "edad": {
+                  "example": "any"
+                },
+                "direccion": {
+                  "example": "any"
+                },
+                "correo": {
+                  "example": "any"
+                },
+                "tipo_relacion": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/materias-primas/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/materias-primas/nombres-id": {
+      "get": {
+        "description": "",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/api/compra/": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cedula_proveedor": {
+                  "example": "any"
+                },
+                "metodo_pago": {
+                  "example": "any"
+                },
+                "observaciones": {
+                  "example": "any"
+                },
+                "detalles": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/controllers/auth.Controller.js
+++ b/src/controllers/auth.Controller.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import jwt from 'jsonwebtoken'
 import { getUserByUsername } from '../dao/usuario.dao.js'
 

--- a/src/controllers/compra.controller.js
+++ b/src/controllers/compra.controller.js
@@ -1,18 +1,19 @@
+/* eslint-disable camelcase */
 import CompraService from '../services/compra.service.js'
 
 class compraController {
   static async registrarCompra (req, res) {
     try {
-      const { id_proveedor, metodo_pago, observaciones, detalles } = req.body
+      const { cedula_proveedor, metodo_pago, observaciones, detalles } = req.body
 
-      if (!id_proveedor || !metodo_pago || !detalles || !observaciones) {
+      if (!cedula_proveedor || !metodo_pago || !detalles || !observaciones) {
         return res.status(400).json({ success: false, message: 'Todos los campos son obligatorios' })
       }
       const total = detalles.reduce((sum, detalle) =>
         sum + (detalle.cantidad * detalle.precio_unitario), 0
       )
 
-      const response = await CompraService.registrarCompra(id_proveedor, metodo_pago, observaciones, detalles, total)
+      const response = await CompraService.registrarCompra(cedula_proveedor, metodo_pago, observaciones, detalles, total)
 
       if (response.success) {
         return res.status(201).json({ message: response.message })

--- a/src/controllers/createClienteProveedor.controller.js
+++ b/src/controllers/createClienteProveedor.controller.js
@@ -1,10 +1,11 @@
+/* eslint-disable camelcase */
 import Cliente_proveedorService from '../services/cliente_proveedor.service.js'
 
 export const create = async (req, res) => {
   try {
     const { cedula_nit, nombre, apellido, celular, tipo_persona, edad, direccion, correo, tipo_relacion } = req.body
 
-    if (!cedula_nit || !nombre || !apellido || !celular || !tipo_persona || !edad || !direccion || !correo || !tipo_relacion) {
+    if (!cedula_nit || !nombre || !celular || !tipo_persona || !direccion || !correo || !tipo_relacion) {
       return res.status(400).json({ success: false, message: 'Todos los campos son obligatorios' })
     }
     const response = await Cliente_proveedorService.create(cedula_nit, nombre, apellido, celular, tipo_persona, edad, direccion, correo, tipo_relacion)

--- a/src/controllers/materiaPrima.controller.js
+++ b/src/controllers/materiaPrima.controller.js
@@ -13,7 +13,7 @@ class materiaPrimaController {
   static async obtenerIdMateriasPrimas (req, res) {
     try {
       const materiaPrimas = await MateriaPrimaService.obtenerIdMateriasPrimas()
-      res.status(201).json(materiaPrimas)
+      res.status(200).json(materiaPrimas)
     } catch (error) {
       res.status(500).json({ error: error.message })
     }

--- a/src/dao/cliente_proveedor.dao.js
+++ b/src/dao/cliente_proveedor.dao.js
@@ -1,5 +1,5 @@
 import { dbConnect, mssql } from '../config/conenectionSQLServer.js'
-
+/* eslint-disable camelcase */
 class CreateClienteProveedorDao {
   static async create (
     cedula_nit,

--- a/src/dao/compra.dao.js
+++ b/src/dao/compra.dao.js
@@ -1,23 +1,35 @@
 import { dbConnect, mssql } from '../config/conenectionSQLServer.js'
-
+/* eslint-disable camelcase */
 class compraDao {
-  static async registrarCompra (id_proveedor, metodo_pago, observaciones, detalles, total) {
+  static async registrarCompra (cedula_proveedor, metodo_pago, observaciones, detalles, total) {
     try {
-      // Validar que el total sea correcto antes de proceder
-
-      // Conectar a la base de datos
       const pool = await dbConnect
 
       // Insertar la compra
       const result = await pool
         .request()
-        .input('id_proveedor', mssql.Int, id_proveedor)
+        .input('cedula_proveedor', mssql.NVarChar, cedula_proveedor)
         .input('metodo_pago', mssql.VarChar, metodo_pago)
         .input('observaciones', mssql.NVarChar, observaciones)
         .input('total', mssql.Decimal, total)
         .execute('sp_insertar_compra')
 
-      const id_compra = result.recordset[0].id_compra_creada // ID generado
+      const id_compra = result.recordset[0].id_compra_creada
+
+      // Validar que todas las materias primas existan
+      for (const detalle of detalles) {
+        const materiaResult = await pool
+          .request()
+          .input('id_materia', mssql.Int, detalle.id_materia)
+          .query('SELECT COUNT(*) AS existe FROM materia_prima WHERE id_materia = @id_materia')
+
+        if (materiaResult.recordset[0].existe === 0) {
+          return {
+            success: false,
+            message: `Error: La materia prima con ID ${detalle.id_materia} no existe`
+          }
+        }
+      }
 
       // Insertar los detalles de la compra
       for (const detalle of detalles) {
@@ -36,7 +48,7 @@ class compraDao {
       return { success: true, message: 'Compra registrada correctamente', id_compra }
     } catch (error) {
       console.error('Error al registrar la compra:', error.message)
-      throw new Error(`Error al registrar la compra: ${error.message}`)
+      return { success: false, message: `Error al registrar la compra: ${error.message}` }
     }
   }
 }

--- a/src/routes/materiaPrima.routers.js
+++ b/src/routes/materiaPrima.routers.js
@@ -4,6 +4,6 @@ import materiaPrimaController from '../controllers/materiaPrima.controller.js'
 const router = Router()
 
 router.get('/', materiaPrimaController.obtenerMateriasPrimas)
-router.get('/id-materias-primas', materiaPrimaController.obtenerIdMateriasPrimas)
+router.get('/nombres-id', materiaPrimaController.obtenerIdMateriasPrimas)
 
 export default router

--- a/src/services/compra.service.js
+++ b/src/services/compra.service.js
@@ -1,8 +1,8 @@
 import compraDao from '../dao/compra.dao.js'
 /* eslint-disable camelcase */
 class CompraService {
-  static async registrarCompra (id_proveedor, metodo_pago, observaciones, detalles, total) {
-    return await compraDao.registrarCompra(id_proveedor, metodo_pago, observaciones, detalles, total)
+  static async registrarCompra (cedula_proveedor, metodo_pago, observaciones, detalles, total) {
+    return await compraDao.registrarCompra(cedula_proveedor, metodo_pago, observaciones, detalles, total)
   }
 }
 

--- a/swagger.js
+++ b/swagger.js
@@ -1,6 +1,7 @@
 import swaggerAutogen from 'swagger-autogen'
 
-const outpuFile = './swagger.json'
+// la plantilla que uso se genera con la documentacion NO es la que se sube al final!
+const outpuFile = './GeneraterSwagger.json'
 const endPointsFiles = ['./index.js']
 
 const doc = {

--- a/swagger.json
+++ b/swagger.json
@@ -7,82 +7,27 @@
   },
   "host": "amara-backend-production.up.railway.app",
   "basePath": "/",
-  "schemes": [
-    "https"
-  ],
+  "schemes": ["https"],
   "paths": {
-    "/api/perfil": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        }
-      }
-    },
-    "/api/personas/": {
-      "get": {
-        "description": "",
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/api/personas/{id}": {
-      "get": {
-        "description": "",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "404": {
-            "description": "Not Found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
     "/api/login": {
       "post": {
-        "description": "",
+        "tags": ["Login"],
+        "description": "Autentica a un usuario en el sistema proporcionando su nombre de usuario y contraseña. Si las credenciales son correctas, devuelve un token de autenticación para acceder a los demás recursos protegidos de la API.",
         "parameters": [
           {
             "name": "body",
             "in": "body",
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
                 "nombre_usuario": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "usuario123"
                 },
                 "password": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "contraseñaSegura"
                 }
               }
             }
@@ -90,79 +35,165 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Autenticación exitosa. Devuelve un token de acceso."
           },
           "400": {
-            "description": "Bad Request"
+            "description": "Solicitud incorrecta. Datos faltantes o en formato incorrecto."
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "No autorizado. Credenciales incorrectas."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }
     },
     "/api/verify": {
       "get": {
-        "description": "",
+        "tags": ["Login"],
+        "description": "Verifica la validez del token de autenticación enviado en el encabezado de la solicitud. Si el token es válido, el usuario puede continuar accediendo a los recursos protegidos. (aun no funcional)",
         "parameters": [
           {
             "name": "authorization",
             "in": "header",
-            "type": "string"
+            "required": true,
+            "type": "string",
+            "description": "Token JWT de autenticación en formato 'Bearer <token>'"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Token válido. El usuario puede acceder a los recursos protegidos."
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "No autorizado. Token ausente, inválido o expirado."
           },
           "403": {
-            "description": "Forbidden"
+            "description": "Prohibido. El usuario no tiene los permisos necesarios."
+          }
+        }
+      }
+    },
+    "/api/perfil": {
+      "get": {
+        "tags": ["Login"],
+        "description": "Obtiene la información del perfil del usuario autenticado. Requiere un token de autenticación válido. (aun no funcional)",
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "type": "string",
+            "description": "Token JWT de autenticación en formato 'Bearer <token>'"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Perfil del usuario obtenido correctamente."
+          },
+          "401": {
+            "description": "No autorizado. Token inválido o expirado."
+          }
+        }
+      }
+    },
+    "/api/personas/": {
+      "get": {
+        "tags": ["Personas"],
+        "description": "Obtiene una lista de todas las personas registradas en el sistema.",
+        "responses": {
+          "200": {
+            "description": "Lista de personas obtenida correctamente."
+          },
+          "500": {
+            "description": "Error interno del servidor."
+          }
+        }
+      }
+    },
+    "/api/personas/{id}": {
+      "get": {
+        "tags": ["Personas"],
+        "description": "Obtiene la información de una persona específica según su ID.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "ID único de la persona a consultar."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Información de la persona obtenida correctamente."
+          },
+          "404": {
+            "description": "No encontrado. No existe una persona con ese ID."
+          },
+          "500": {
+            "description": "Error interno del servidor."
           }
         }
       }
     },
     "/api/cliente/createCltProv": {
       "post": {
-        "description": "",
+        "tags": ["Cliente"],
+        "description": "Registra un nuevo cliente en el sistema. Si el cliente es una empresa (tipo_persona = 'juridica'), los campos 'apellido' y 'edad' pueden ser nulos. \nSi es una persona (tipo_persona = 'natural')",
         "parameters": [
           {
             "name": "body",
             "in": "body",
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
                 "cedula_nit": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "123456789",
+                  "description": "Número de cédula o NIT del cliente."
                 },
                 "nombre": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Empresa XYZ",
+                  "description": "Nombre del cliente o razón social si es una empresa."
                 },
                 "apellido": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Pérez",
+                  "description": "Apellido del cliente. Puede ser nulo si es una empresa."
                 },
                 "celular": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "3001234567",
+                  "description": "Número de celular del cliente."
                 },
                 "tipo_persona": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "juridica",
+                  "description": "Tipo de persona: 'Natural' o 'Jurídica'."
                 },
                 "edad": {
-                  "example": "any"
+                  "type": "integer",
+                  "example": 30,
+                  "description": "Edad del cliente. Puede ser nulo si es una empresa."
                 },
                 "direccion": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Calle 123",
+                  "description": "Dirección del cliente."
                 },
                 "correo": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "empresa@xyz.com",
+                  "description": "Correo electrónico del cliente."
                 },
                 "tipo_relacion": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "cliente",
+                  "description": "Define si la persona es un 'cliente'."
                 }
               }
             }
@@ -170,53 +201,73 @@
         ],
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "Cliente creado exitosamente."
           },
           "400": {
-            "description": "Bad Request"
+            "description": "Solicitud incorrecta. Datos inválidos o incompletos."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }
     },
     "/api/proveedor/createCltProv": {
       "post": {
-        "description": "",
+        "tags": ["Proveedor"],
+        "description": "Registra un nuevo proveedor en el sistema. Si el proveedor es una empresa (tipo_persona = 'juridica'), los campos 'apellido' y 'edad' pueden ser nulos. \nSi es una persona (tipo_persona = 'natural')",
         "parameters": [
           {
             "name": "body",
             "in": "body",
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
                 "cedula_nit": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "123456789",
+                  "description": "Número de cédula o NIT del cliente."
                 },
                 "nombre": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Empresa XYZ",
+                  "description": "Nombre del cliente o razón social si es una empresa."
                 },
                 "apellido": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Pérez",
+                  "description": "Apellido del cliente. Puede ser nulo si es una empresa."
                 },
                 "celular": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "3001234567",
+                  "description": "Número de celular del cliente."
                 },
                 "tipo_persona": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "juridica",
+                  "description": "Tipo de persona: 'Natural' o 'Jurídica'."
                 },
                 "edad": {
-                  "example": "any"
+                  "type": "integer",
+                  "example": 30,
+                  "description": "Edad del cliente. Puede ser nulo si es una empresa."
                 },
                 "direccion": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Calle 123",
+                  "description": "Dirección del cliente."
                 },
                 "correo": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "empresa@xyz.com",
+                  "description": "Correo electrónico del cliente."
                 },
                 "tipo_relacion": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "proveedor",
+                  "description": "Define si la persona es un 'proveedor'."
                 }
               }
             }
@@ -224,64 +275,118 @@
         ],
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "Cliente creado exitosamente."
           },
           "400": {
-            "description": "Bad Request"
+            "description": "Solicitud incorrecta. Datos inválidos o incompletos."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }
     },
     "/api/materias-primas/": {
       "get": {
-        "description": "",
+        "tags": ["Materias Primas"],
+        "description": "Obtiene una lista de todas las materias primas registradas en el sistema.",
         "responses": {
-          "201": {
-            "description": "Created"
+          "200": {
+            "description": "Lista de materias primas obtenida correctamente."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }
     },
-    "/api/materias-primas/id-materias-primas": {
+    "/api/materias-primas/nombres-id": {
       "get": {
-        "description": "",
+        "tags": ["Materias Primas"],
+        "description": "Obtiene una lista de materias primas con solo su ID y nombre.",
         "responses": {
-          "201": {
-            "description": "Created"
+          "200": {
+            "description": "Lista de nombres de materias primas obtenida correctamente.",
+            "content": {
+              "application/json": {
+                "example": [
+                  {
+                    "id_materia": 3,
+                    "nombre": "Leche"
+                  },
+                  {
+                    "id_materia": 4,
+                    "nombre": "Sal"
+                  },
+                  {
+                    "id_materia": 5,
+                    "nombre": "Cuajo"
+                  },
+                  {
+                    "id_materia": 6,
+                    "nombre": "Nitrato"
+                  }
+                ]
+              }
+            }
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }
     },
     "/api/compra/": {
       "post": {
-        "description": "",
+        "tags": ["Compra"],
+        "description": "Registra una nueva compra en el sistema, asociada a un proveedor. También permite agregar detalles de los productos adquiridos.",
         "parameters": [
           {
             "name": "body",
             "in": "body",
+            "required": true,
             "schema": {
               "type": "object",
               "properties": {
-                "id_proveedor": {
-                  "example": "any"
+                "cedula_proveedor": {
+                  "type": "string",
+                  "example": "123456789",
+                  "description": "Cédula o NIT del proveedor asociado a la compra."
                 },
                 "metodo_pago": {
-                  "example": "any"
+                  "type": "string",
+                  "enum": ["efectivo", "tarjeta", "transferencia"],
+                  "example": "transferencia",
+                  "description": "Método de pago utilizado. Valores permitidos: 'efectivo', 'tarjeta', 'transferencia'."
                 },
                 "observaciones": {
-                  "example": "any"
+                  "type": "string",
+                  "example": "Compra de insumos para producción.",
+                  "description": "Notas adicionales sobre la compra."
                 },
                 "detalles": {
-                  "example": "any"
+                  "type": "array",
+                  "description": "Lista de detalles de los productos adquiridos en la compra.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id_materia": {
+                        "type": "integer",
+                        "example": 1,
+                        "description": "ID de la materia prima adquirida."
+                      },
+                      "cantidad": {
+                        "type": "number",
+                        "example": 10.5,
+                        "description": "Cantidad de materia prima adquirida."
+                      },
+                      "precio_unitario": {
+                        "type": "number",
+                        "example": 5.75,
+                        "description": "Precio unitario de la materia prima."
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -289,13 +394,13 @@
         ],
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "Compra registrada exitosamente."
           },
           "400": {
-            "description": "Bad Request"
+            "description": "Solicitud incorrecta. Datos inválidos o incompletos."
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Error interno del servidor."
           }
         }
       }


### PR DESCRIPTION
feat: validar existencia de materia prima y mejorar documentación

- Se agregó validación para verificar que las materias primas existen antes de registrar una compra.
- Se ajustó la documentación del endpoint `/api/materias-primas/id-materias-primas` para reflejar que solo devuelve ID y nombre.
- Se corrigió la restricción en la base de datos para el método de pago (se arregló "trasnferencia" a "transferencia").
- Se actualizaron las validaciones en el endpoint de creación de clientes para permitir `apellido` y `edad` nulos cuando es una empresa.
