### PR TITLE
fix: removed exposed AWS keys

### DIFF
--- a/.github/workflows/update-sg.yml
+++ b/.github/workflows/update-sg.yml
@@ -1,0 +1,34 @@
+name: Update RDS Security Group
+
+on:
+  push:
+    branches:
+      - railway-connect-api
+
+jobs:
+  update-security-group:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Get public IP
+        id: ip
+        run: |
+          echo "IP=$(curl -s https://api.ipify.org)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+
+      - name: Authorize IP in Security Group
+        run: |
+          aws ec2 authorize-security-group-ingress \
+            --group-id sg-07e6b696f4d7029ac \
+            --protocol tcp \
+            --port 1433 \
+            --cidr ${{ steps.ip.outputs.IP }}/32 || echo "IP already authorized or error occurred"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to update the RDS Security Group for the `railway-connect-api` branch. The most important changes include setting up the workflow, configuring AWS credentials, and authorizing the public IP in the security group.

New GitHub Actions workflow:

* [`.github/workflows/update-sg.yml`](diffhunk://#diff-e0566d405a8ac88d573ebcdac4848c5bbda6e413bd9003bd979dbb37e23d213aR1-R34): Created a new workflow named "Update RDS Security Group" that triggers on pushes to the `railway-connect-api` branch. This workflow includes steps to check out the repository, retrieve the public IP, configure AWS credentials, and authorize the IP in the specified security group.